### PR TITLE
chore(ci): Change build ci steps order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,13 +30,13 @@ jobs:
       run: |
         poetry install
 
-    - name: Run style checks
-      run: |
-        make check-codestyle
-
     - name: Run tests
       run: |
         make test
+
+    - name: Run style checks
+      run: |
+        make check-codestyle
 
     - name: Run safety checks
       run: |


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR aims to change the order some steps and execute lint and security check steps always (even when tests fail)

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->
Resolves #69 

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/thegraphnetwork/epigraphhub_py/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/thegraphnetwork/epigraphhub_py/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
