### PR TITLE
chore(semantic-release): Include 'exec' dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,7 @@ jobs:
           -p "@semantic-release/commit-analyzer" \
           -p "@semantic-release/release-notes-generator" \
           -p "@semantic-release/changelog" \
+          -p "@semantic-release/exec" \
           -p "@semantic-release/github" \
           -p "@semantic-release/git" \
           -p "@google/semantic-release-replace-plugin" \


### PR DESCRIPTION
## Description

Add exec plugin used by semantic-release.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->


## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/thegraphnetwork/epigraphhub_py/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/thegraphnetwork/epigraphhub_py/blob/master/CONTRIBUTING.md) guide.
- [x] I've used pre-commit hook locally.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
- [x] Semantic-release prefix title used:
  - Use the prefix `chore(docs):` for Examples / docs / tutorials / dependencies update
  - Use the prefix `fix:` for a bug fix 
    (non-breaking change which fixes an issue).
  - Use the prefix `chore(improvement):` for an improvement
    (non-breaking change which improves an existing feature).
  - Use the prefix `feat:` for a new feature
    (non-breaking change which adds functionality).
  - Use the prefix `breaking change:` for a breaking change
    (fix or feature that would cause existing functionality to change).
  - Use the prefix `chore(security):` for a security fix.


**Note**: The title prefix can be also expanded with more information
inside the parenthesis. Some examples for a full title (prefix + message): 
- `fix(login): Fix the login page`.
- `feat(forecast): Add a weather forecast page`.
- `chore(security-login): Add a weather forecast page`.
